### PR TITLE
Localization via Twilio strings

### DIFF
--- a/chat-staging.html
+++ b/chat-staging.html
@@ -5,15 +5,62 @@
 <body>
     <script src="https://media.twiliocdn.com/sdk/js/flex-webchat/releases/2.1.2/twilio-flex-webchat.min.js"></script>
     <script>
+        const translations = {
+          'en-US': {
+            PreEngagementConfigDescription: "Let's get started",
+            PreEngagementConfigWhatHelpline: "What is your helpline?",
+            PreEngagementConfigSelectHelpline: "Select helpline",
+            PreEngagementConfigSubmitLabel: "Let's chat!",
+
+            BotGreeting: "How can I help?",
+            WelcomeMessage: "Welcome to Toronto Line!",
+            MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
+          },
+          'es': {
+            EntryPointTagline: "Chatea con nosotros",
+            MessageCanvasTrayButton: "EMPEZAR NUEVO CHAT",
+            InvalidPreEngagementMessage: "Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.",
+            InvalidPreEngagementButton: "Aprende más",
+            PredefinedChatMessageAuthorName: "Bot",
+            PredefinedChatMessageBody: "¡Hola! ¿Cómo podemos ayudarte hoy?",
+            InputPlaceHolder: "Escribe un mensaje",
+            TypingIndicator: "{0} está escribiendo ... ",
+            Read: "Visto",
+            MessageSendingDisabled: "El envío de mensajes ha sido desactivado",
+            Today: "HOY",
+            Yesterday: "AYER",
+            Save: "GUARDAR",
+            Reset: "RESETEAR",
+            MessageCharacterCountStatus: "{{currentCharCount}} / {{maxCharCount}}",
+            SendMessageTooltip: "Enviar Mensaje",
+            FieldValidationRequiredField: "Campo requerido",
+            FieldValidationInvalidEmail: "Por favor provea una dirección válida de email",
+
+            PreEngagementConfigDescription: "Comencemos",
+            PreEngagementConfigWhatHelpline: "¿Cuál es tu línea de asistencia?",
+            PreEngagementConfigSelectHelpline: "Seleccione línea de asistencia",
+            PreEngagementConfigSubmitLabel: "¡A chatear!",
+
+            BotGreeting: "¿Cómo puedo ayudar?",
+            WelcomeMessage: "¡Bienvenido a Toronto Line!",
+            MessageCanvasTrayContent: "<p>El consejero abandonó el chat. Gracias por contactarnos. Por favor contáctenos nuevamente si necesita más ayuda.</p>",
+          }
+        }
+
+        const defaultLanguage = 'en-US';
+        // const helplineLanguage = 'es';
+        const helplineLanguage = defaultLanguage;
+        const webchatLanguage = helplineLanguage || defaultLanguage;
+
         const appConfig = {
             accountSid:"ACd8a2e89748318adf6ddff7df6948deaf",
             flexFlowSid:"FO8c2d9c388e7feba8b08d06a4bc3f69d1",
             startEngagementOnInit: false,
             preEngagementConfig: {
-                description: "Let's get started",
+                description: translations[webchatLanguage].PreEngagementConfigDescription,
                 fields:
                     [{
-                        label: "What is your helpline?",
+                        label: translations[webchatLanguage].PreEngagementConfigWhatHelpline,
                         type: "SelectItem",
                         attributes: 
                         {
@@ -24,20 +71,17 @@
                         options: [
                         {
                             value: "Select helpline",
-                            label: "Select helpline",
+                            label: translations[webchatLanguage].PreEngagementConfigSelectHelpline,
                             selected: true
                         }
                         ]
                     }],
-                submitLabel: "Let's chat!"
+                submitLabel: translations[webchatLanguage].PreEngagementConfigSubmitLabel,
             }
         };
-        const defaultLanguage = 'en-US';
-        const helplineLanguage = 'es';
 
         Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
             const { manager } = webchat;
-            const serverlessBaseUrl = manager.serviceConfiguration.attributes.serverless_base_url;
             
             const twilioStrings = { ...manager.strings }; // save the originals
             const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
@@ -45,13 +89,13 @@
 
             const changeLanguageWebChat = async language => {
               try {
-                const response = await fetch(`${serverlessBaseUrl}/translations/${language}/messages.json`);
-                const translation = await response.json();
+                let translation;
                 if (language === defaultLanguage) {
-                  setNewStrings({ ...twilioStrings, ...translation });
+                  translation = { ...twilioStrings, ...translations[defaultLanguage] };
                 } else {
-                  setNewStrings(translation);
+                  translation = translations[language];
                 }
+                setNewStrings(translation)
                 Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body = translation.BotGreeting;
                 console.log('Translation OK');
               } catch (err) {
@@ -61,7 +105,6 @@
               }
             }
 
-            const webchatLanguage = helplineLanguage || defaultLanguage;
             changeLanguageWebChat(webchatLanguage).then(() =>{
               //Posting question from preengagement form as users first chat message
               Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -50,7 +50,7 @@
         flexFlowSid:"FO8c2d9c388e7feba8b08d06a4bc3f69d1",
         startEngagementOnInit: false,
         preEngagementConfig: {
-          description: translations[webchatLanguage].PreEngagementDescription,
+          description: translations[webchatLanguage].PreEngagementDescription || "Let's get started",
           fields:
             [{
               label: "What is your helpline?",

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -40,11 +40,6 @@
         }
 
         const defaultLanguage = 'en-US';
-        // const defaultLanguage = 'es';
-        // const userLanguage = window.navigator.language;
-        // console.log(userLanguage)
-        // const webchatLanguage = 
-        //   translations.userLanguage ? userLanguage : userLanguage.slice(0, 2) ? userLanguage.slice(0, 2) : defaultLanguage;
         const webchatLanguage = defaultLanguage;
 
         const appConfig = {

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -7,11 +7,6 @@
     <script>
         const translations = {
           'en-US': {
-            PreEngagementConfigDescription: "Let's get started",
-            PreEngagementConfigWhatHelpline: "What is your helpline?",
-            PreEngagementConfigSelectHelpline: "Select helpline",
-            PreEngagementConfigSubmitLabel: "Let's chat!",
-
             BotGreeting: "How can I help?",
             WelcomeMessage: "Welcome to Toronto Line!",
             MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
@@ -36,10 +31,7 @@
             FieldValidationRequiredField: "Campo requerido",
             FieldValidationInvalidEmail: "Por favor provea una dirección válida de email",
 
-            PreEngagementConfigDescription: "Comencemos",
-            PreEngagementConfigWhatHelpline: "¿Cuál es tu línea de asistencia?",
-            PreEngagementConfigSelectHelpline: "Seleccione línea de asistencia",
-            PreEngagementConfigSubmitLabel: "¡A chatear!",
+            PreEngagementDescription: "Comencemos",
 
             BotGreeting: "¿Cómo puedo ayudar?",
             WelcomeMessage: "¡Bienvenido a Toronto Line!",
@@ -48,19 +40,22 @@
         }
 
         const defaultLanguage = 'en-US';
-        // const helplineLanguage = 'es';
-        const helplineLanguage = defaultLanguage;
-        const webchatLanguage = helplineLanguage || defaultLanguage;
+        // const defaultLanguage = 'es';
+        // const userLanguage = window.navigator.language;
+        // console.log(userLanguage)
+        // const webchatLanguage = 
+        //   translations.userLanguage ? userLanguage : userLanguage.slice(0, 2) ? userLanguage.slice(0, 2) : defaultLanguage;
+        const webchatLanguage = defaultLanguage;
 
         const appConfig = {
             accountSid:"ACd8a2e89748318adf6ddff7df6948deaf",
             flexFlowSid:"FO8c2d9c388e7feba8b08d06a4bc3f69d1",
             startEngagementOnInit: false,
             preEngagementConfig: {
-                description: translations[webchatLanguage].PreEngagementConfigDescription,
+                description: translations[webchatLanguage].PreEngagementDescription,
                 fields:
                     [{
-                        label: translations[webchatLanguage].PreEngagementConfigWhatHelpline,
+                      label: "What is your helpline?",
                         type: "SelectItem",
                         attributes: 
                         {
@@ -71,14 +66,28 @@
                         options: [
                         {
                             value: "Select helpline",
-                            label: translations[webchatLanguage].PreEngagementConfigSelectHelpline,
+                            label: "Select helpline",
                             selected: true
-                        }
+                        },
+                        {
+                            value: "Fake Helpline",
+                            label: "Fake Helpline",
+                            selected: false
+                        },
                         ]
                     }],
-                submitLabel: translations[webchatLanguage].PreEngagementConfigSubmitLabel,
+                submitLabel: "Let's chat!"
             }
         };
+
+        const mapHelplineLanguage = helpline => {
+          switch (helpline) {
+            case 'Fake Helpline':
+              return 'es';
+            default:
+              return defaultLanguage;
+          }
+        }
 
         Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
             const { manager } = webchat;
@@ -87,7 +96,7 @@
             const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
             const translationErrorMsg = 'Could not translate, using default';
 
-            const changeLanguageWebChat = async language => {
+            const changeLanguageWebChat = language => {
               try {
                 let translation;
                 if (language === defaultLanguage) {
@@ -99,16 +108,20 @@
                 Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body = translation.BotGreeting;
                 console.log('Translation OK');
               } catch (err) {
+                changeLanguageWebChat(defaultLanguage)
                 window.alert(translationErrorMsg);
                 console.error(translationErrorMsg, err);
-                changeLanguageWebChat(defaultLanguage)
               }
             }
 
-            changeLanguageWebChat(webchatLanguage).then(() =>{
               //Posting question from preengagement form as users first chat message
               Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
-                  const { question } = payload.formData;
+                  const { question, helpline } = payload.formData;
+
+                  // here we might collect caller language (from a another preEngagement select)
+                  const helplineLanguage = mapHelplineLanguage(helpline);
+                  changeLanguageWebChat(helplineLanguage);
+
                   if (!question)
                       return;
 
@@ -120,7 +133,6 @@
 
               // Render WebChat
               webchat.init();
-            })
         });
     </script>
 </body>

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -97,12 +97,12 @@
         const changeLanguageWebChat = language => {
           try {
             if (language === defaultLanguage) {
-              setNewStrings(translations[defaultLanguage]);
+              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
             } else {
-              setNewStrings(translations[language]);
+              setNewStrings({ ...twilioStrings, ...translations[language] });
             }
             Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body =
-            (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
+              (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
             console.log('Translation OK');
           } catch (err) {
             window.alert(translationErrorMsg);

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -43,14 +43,14 @@
       }
 
       const defaultLanguage = 'en-US';
-      const webchatLanguage = defaultLanguage;
+      const initialLanguage = defaultLanguage;
 
       const appConfig = {
         accountSid:"ACd8a2e89748318adf6ddff7df6948deaf",
         flexFlowSid:"FO8c2d9c388e7feba8b08d06a4bc3f69d1",
         startEngagementOnInit: false,
         preEngagementConfig: {
-          description: translations[webchatLanguage].PreEngagementDescription || "Let's get started",
+          description: "Let's get started",
           fields:
             [{
               label: "What is your helpline?",
@@ -96,10 +96,10 @@
 
         const changeLanguageWebChat = language => {
           try {
-            if (language === defaultLanguage) {
-              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
+            if (language !== defaultLanguage && translations[language]) {
+              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage], ...translations[language] });
             } else {
-              setNewStrings({ ...twilioStrings, ...translations[language] });
+              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
             }
             Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body =
               (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
@@ -110,6 +110,8 @@
             changeLanguageWebChat(defaultLanguage)
           }
         }
+
+        changeLanguageWebChat(initialLanguage);
 
         //Posting question from preengagement form as users first chat message
         Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -5,130 +5,132 @@
 <body>
     <script src="https://media.twiliocdn.com/sdk/js/flex-webchat/releases/2.1.2/twilio-flex-webchat.min.js"></script>
     <script>
-        const translations = {
-          'en-US': {
-            BotGreeting: "How can I help?",
-            WelcomeMessage: "Welcome to Toronto Line!",
-            MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
-          },
-          'es': {
-            EntryPointTagline: "Chatea con nosotros",
-            MessageCanvasTrayButton: "EMPEZAR NUEVO CHAT",
-            InvalidPreEngagementMessage: "Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.",
-            InvalidPreEngagementButton: "Aprende más",
-            PredefinedChatMessageAuthorName: "Bot",
-            PredefinedChatMessageBody: "¡Hola! ¿Cómo podemos ayudarte hoy?",
-            InputPlaceHolder: "Escribe un mensaje",
-            TypingIndicator: "{0} está escribiendo ... ",
-            Read: "Visto",
-            MessageSendingDisabled: "El envío de mensajes ha sido desactivado",
-            Today: "HOY",
-            Yesterday: "AYER",
-            Save: "GUARDAR",
-            Reset: "RESETEAR",
-            MessageCharacterCountStatus: "{{currentCharCount}} / {{maxCharCount}}",
-            SendMessageTooltip: "Enviar Mensaje",
-            FieldValidationRequiredField: "Campo requerido",
-            FieldValidationInvalidEmail: "Por favor provea una dirección válida de email",
+      const translations = {
+        'en-US': {
+          BotGreeting: "How can I help?",
+          WelcomeMessage: "Welcome to Toronto Line!",
+          MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
+        },
+        'es': {
+          EntryPointTagline: "Chatea con nosotros",
+          MessageCanvasTrayButton: "EMPEZAR NUEVO CHAT",
+          InvalidPreEngagementMessage: "Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.",
+          InvalidPreEngagementButton: "Aprende más",
+          PredefinedChatMessageAuthorName: "Bot",
+          PredefinedChatMessageBody: "¡Hola! ¿Cómo podemos ayudarte hoy?",
+          InputPlaceHolder: "Escribe un mensaje",
+          TypingIndicator: "{0} está escribiendo ... ",
+          Read: "Visto",
+          MessageSendingDisabled: "El envío de mensajes ha sido desactivado",
+          Today: "HOY",
+          Yesterday: "AYER",
+          Save: "GUARDAR",
+          Reset: "RESETEAR",
+          MessageCharacterCountStatus: "{{currentCharCount}} / {{maxCharCount}}",
+          SendMessageTooltip: "Enviar Mensaje",
+          FieldValidationRequiredField: "Campo requerido",
+          FieldValidationInvalidEmail: "Por favor provea una dirección válida de email",
 
-            PreEngagementDescription: "Comencemos",
+          PreEngagementDescription: "Comencemos",
 
-            BotGreeting: "¿Cómo puedo ayudar?",
-            WelcomeMessage: "¡Bienvenido a Toronto Line!",
-            MessageCanvasTrayContent: "<p>El consejero abandonó el chat. Gracias por contactarnos. Por favor contáctenos nuevamente si necesita más ayuda.</p>",
+          BotGreeting: "¿Cómo puedo ayudar?",
+          WelcomeMessage: "¡Bienvenido a Toronto Line!",
+          MessageCanvasTrayContent: "<p>El consejero abandonó el chat. Gracias por contactarnos. Por favor contáctenos nuevamente si necesita más ayuda.</p>",
+        },
+        'dk': {
+          MessageCanvasTrayContent: "<p>Rådgiveren har forladt chatten. Tak, fordi du nåede ud. Kontakt os igen, hvis du har brug for mere hjælp.</p>",
+        }
+      }
+
+      const defaultLanguage = 'en-US';
+      const webchatLanguage = defaultLanguage;
+
+      const appConfig = {
+        accountSid:"ACd8a2e89748318adf6ddff7df6948deaf",
+        flexFlowSid:"FO8c2d9c388e7feba8b08d06a4bc3f69d1",
+        startEngagementOnInit: false,
+        preEngagementConfig: {
+          description: translations[webchatLanguage].PreEngagementDescription,
+          fields:
+            [{
+              label: "What is your helpline?",
+              type: "SelectItem",
+              attributes:
+              {
+                name: "helpline",
+                required: true,
+                readOnly: false
+              },
+              options: [
+                {
+                  value: "Select helpline",
+                  label: "Select helpline",
+                  selected: true
+                },
+                {
+                  value: "Fake Helpline",
+                  label: "Fake Helpline",
+                  selected: false
+                },
+              ]
+            }],
+          submitLabel: "Let's chat!"
+        }
+      };
+
+      const mapHelplineLanguage = helpline => {
+        switch (helpline) {
+          case 'Fake Helpline':
+            return 'dk';
+          default:
+            return defaultLanguage;
+        }
+      }
+
+      Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
+        const { manager } = webchat;
+
+        const twilioStrings = { ...manager.strings }; // save the originals
+        const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
+        const translationErrorMsg = 'Could not translate, using default';
+
+        const changeLanguageWebChat = language => {
+          try {
+            if (language === defaultLanguage) {
+              setNewStrings(translations[defaultLanguage]);
+            } else {
+              setNewStrings(translations[language]);
+            }
+            Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body =
+            (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
+            console.log('Translation OK');
+          } catch (err) {
+            window.alert(translationErrorMsg);
+            console.error(translationErrorMsg, err);
+            changeLanguageWebChat(defaultLanguage)
           }
         }
 
-        const defaultLanguage = 'en-US';
-        const webchatLanguage = defaultLanguage;
+        //Posting question from preengagement form as users first chat message
+        Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
+          const { question, helpline } = payload.formData;
 
-        const appConfig = {
-            accountSid:"ACd8a2e89748318adf6ddff7df6948deaf",
-            flexFlowSid:"FO8c2d9c388e7feba8b08d06a4bc3f69d1",
-            startEngagementOnInit: false,
-            preEngagementConfig: {
-                description: translations[webchatLanguage].PreEngagementDescription,
-                fields:
-                    [{
-                      label: "What is your helpline?",
-                        type: "SelectItem",
-                        attributes: 
-                        {
-                            name: "helpline",
-                            required: true,
-                            readOnly: false
-                        },
-                        options: [
-                        {
-                            value: "Select helpline",
-                            label: "Select helpline",
-                            selected: true
-                        },
-                        {
-                            value: "Fake Helpline",
-                            label: "Fake Helpline",
-                            selected: false
-                        },
-                        ]
-                    }],
-                submitLabel: "Let's chat!"
-            }
-        };
+          // here we might collect caller language (from a another preEngagement select)
+          const helplineLanguage = mapHelplineLanguage(helpline);
+          changeLanguageWebChat(helplineLanguage);
 
-        const mapHelplineLanguage = helpline => {
-          switch (helpline) {
-            case 'Fake Helpline':
-              return 'es';
-            default:
-              return defaultLanguage;
-          }
-        }
+          if (!question)
+            return;
 
-        Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
-            const { manager } = webchat;
-            
-            const twilioStrings = { ...manager.strings }; // save the originals
-            const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
-            const translationErrorMsg = 'Could not translate, using default';
-
-            const changeLanguageWebChat = language => {
-              try {
-                let translation;
-                if (language === defaultLanguage) {
-                  translation = { ...twilioStrings, ...translations[defaultLanguage] };
-                } else {
-                  translation = translations[language];
-                }
-                setNewStrings(translation)
-                Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body = translation.BotGreeting;
-                console.log('Translation OK');
-              } catch (err) {
-                changeLanguageWebChat(defaultLanguage)
-                window.alert(translationErrorMsg);
-                console.error(translationErrorMsg, err);
-              }
-            }
-
-              //Posting question from preengagement form as users first chat message
-              Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
-                  const { question, helpline } = payload.formData;
-
-                  // here we might collect caller language (from a another preEngagement select)
-                  const helplineLanguage = mapHelplineLanguage(helpline);
-                  changeLanguageWebChat(helplineLanguage);
-
-                  if (!question)
-                      return;
-
-                  const { channelSid } = manager.store.getState().flex.session;
-                  manager
-                      .chatClient.getChannelBySid(channelSid)
-                      .then(channel => channel.sendMessage(question));
-              });
-
-              // Render WebChat
-              webchat.init();
+          const { channelSid } = manager.store.getState().flex.session;
+          manager
+            .chatClient.getChannelBySid(channelSid)
+            .then(channel => channel.sendMessage(question));
         });
+
+        // Render WebChat
+        webchat.init();
+      });
     </script>
 </body>
 </html>

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -32,30 +32,52 @@
                 submitLabel: "Let's chat!"
             }
         };
+        const defaultLanguage = 'en-US';
+        const helplineLanguage = 'es';
+
         Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
             const { manager } = webchat;
-            Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body = "How can I help?";
-        
-            //Posting question from preengagement form as users first chat message
-             Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
-                 const { question } = payload.formData;
-                 if (!question)
-                    return;
+            const serverlessBaseUrl = manager.serviceConfiguration.attributes.serverless_base_url;
+            
+            const twilioStrings = { ...manager.strings }; // save the originals
+            const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
+            const translationErrorMsg = 'Could not translate, using default';
 
-                const { channelSid } = manager.store.getState().flex.session;
-                manager
-                    .chatClient.getChannelBySid(channelSid)
-                    .then(channel => channel.sendMessage(question));
-            });
-            // Changing the Welcome message
-            manager.strings.WelcomeMessage = "Welcome to Toronto Line!";
-            manager.strings.MessageCanvasTrayContent = `
-              <p>The counselor has left the chat.
-              Thank you for reaching out.
-              Please contact us again if you need more help.</p>
-            `;
-            // Render WebChat
-            webchat.init();
+            const changeLanguageWebChat = async language => {
+              try {
+                const response = await fetch(`${serverlessBaseUrl}/translations/${language}/messages.json`);
+                const translation = await response.json();
+                if (language === defaultLanguage) {
+                  setNewStrings({ ...twilioStrings, ...translation });
+                } else {
+                  setNewStrings(translation);
+                }
+                Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body = translation.BotGreeting;
+                console.log('Translation OK');
+              } catch (err) {
+                window.alert(translationErrorMsg);
+                console.error(translationErrorMsg, err);
+                changeLanguageWebChat(defaultLanguage)
+              }
+            }
+
+            const webchatLanguage = helplineLanguage || defaultLanguage;
+            changeLanguageWebChat(webchatLanguage).then(() =>{
+              //Posting question from preengagement form as users first chat message
+              Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
+                  const { question } = payload.formData;
+                  if (!question)
+                      return;
+
+                  const { channelSid } = manager.store.getState().flex.session;
+                  manager
+                      .chatClient.getChannelBySid(channelSid)
+                      .then(channel => channel.sendMessage(question));
+              });
+
+              // Render WebChat
+              webchat.init();
+            })
         });
     </script>
 </body>

--- a/chat.html
+++ b/chat.html
@@ -5,118 +5,190 @@
 <body>
     <script src="https://media.twiliocdn.com/sdk/js/flex-webchat/releases/2.1.2/twilio-flex-webchat.min.js"></script>
     <script>
-        const appConfig = {
-            accountSid:"AC6b99858a6faf7af1b572c83988b50eb1",
-            flexFlowSid:"FO57c22d5dfc7a18dcada507aa70ca0cb3",
-            startEngagementOnInit: false,
-            preEngagementConfig: {
-                description: "Let's get started",
-                fields:
-                    [{
-                        label: "What is your helpline?",
-                        type: "SelectItem",
-                        attributes: 
-                        {
-                            name: "helpline",
-                            required: true,
-                            readOnly: false
-                        },
-                        options: [
-                        {
-                            value: "Select helpline",
-                            label: "Select helpline",
-                            selected: true
-                        },
-                        {
-                            value: "Børns Vilkår (DK)",
-                            label: "Børns Vilkår (DK)",
-                            selected: false
-                        },
-                        {
-                            value: "Childhelp (US)",
-                            label: "Childhelp (US)",
-                            selected: false
-                        },
-                        {
-                            value: "CHILDLINE India (IN)",
-                            label: "CHILDLINE India (IN)",
-                            selected: false
-                        },
-                        {
-                            value: "Childline South Africa (SA)",
-                            label: "Childline South Africa (SA)",
-                            selected: false
-                        },
-                        {
-                            value: "ChildLine Zambia (ZM)",
-                            label: "ChildLine Zambia (ZM)",
-                            selected: false
-                        },
-                        {
-                            value: "Child Helpline Cambodia (KH)",
-                            label: "Child Helpline Cambodia (KH)",
-                            selected: false
-                        },
-                        {
-                            value: "Jordan River 110 (JO)",
-                            label: "Jordan River 110 (JO)",
-                            selected: false
-                        },
-                        {
-                            value: "SMILE OF THE CHILD (GR)",
-                            label: "SMILE OF THE CHILD (GR)",
-                            selected: false
-                        },
-                        {
-                            value: "Telefono Azzurro (IT)",
-                            label: "Telefono Azzurro (IT)",
-                            selected: false
-                        },
-                        {
-                            value: "BRIS (SE)",
-                            label: "BRIS (SE)",
-                            selected: false
-                        },
-                        {
-                            value: "2NDFLOOR (US)",
-                            label: "2NDFLOOR (US)",
-                            selected: false
-                        },
-                        {
-                            value: "Palo Alto Testing (Text)",
-                            label: "Palo Alto Testing (Text)",
-                            selected: false
-                        }
-                        ]
-                    }],
-                submitLabel: "Let's chat!"
-            }
-        };
-        Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
-            const { manager } = webchat;
-            Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body = "How can I help?";
-        
-            //Posting question from preengagement form as users first chat message
-             Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
-                 const { question } = payload.formData;
-                 if (!question)
-                    return;
+      const translations = {
+        'en-US': {
+          BotGreeting: "How can I help?",
+          WelcomeMessage: "Welcome to Toronto Line!",
+          MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
+        },
+        'es': {
+          EntryPointTagline: "Chatea con nosotros",
+          MessageCanvasTrayButton: "EMPEZAR NUEVO CHAT",
+          InvalidPreEngagementMessage: "Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.",
+          InvalidPreEngagementButton: "Aprende más",
+          PredefinedChatMessageAuthorName: "Bot",
+          PredefinedChatMessageBody: "¡Hola! ¿Cómo podemos ayudarte hoy?",
+          InputPlaceHolder: "Escribe un mensaje",
+          TypingIndicator: "{0} está escribiendo ... ",
+          Read: "Visto",
+          MessageSendingDisabled: "El envío de mensajes ha sido desactivado",
+          Today: "HOY",
+          Yesterday: "AYER",
+          Save: "GUARDAR",
+          Reset: "RESETEAR",
+          MessageCharacterCountStatus: "{{currentCharCount}} / {{maxCharCount}}",
+          SendMessageTooltip: "Enviar Mensaje",
+          FieldValidationRequiredField: "Campo requerido",
+          FieldValidationInvalidEmail: "Por favor provea una dirección válida de email",
 
-                const { channelSid } = manager.store.getState().flex.session;
-                manager
-                    .chatClient.getChannelBySid(channelSid)
-                    .then(channel => channel.sendMessage(question));
-            });
-            // Changing the Welcome message
-            manager.strings.WelcomeMessage = "Welcome to Toronto Line!";
-            manager.strings.MessageCanvasTrayContent = `
-              <p>The counselor has left the chat.
-              Thank you for reaching out.
-              Please contact us again if you need more help.</p>
-            `;
-            // Render WebChat
-            webchat.init();
+          PreEngagementDescription: "Comencemos",
+
+          BotGreeting: "¿Cómo puedo ayudar?",
+          WelcomeMessage: "¡Bienvenido a Toronto Line!",
+          MessageCanvasTrayContent: "<p>El consejero abandonó el chat. Gracias por contactarnos. Por favor contáctenos nuevamente si necesita más ayuda.</p>",
+        },
+        'dk': {
+          MessageCanvasTrayContent: "<p>Rådgiveren har forladt chatten. Tak, fordi du nåede ud. Kontakt os igen, hvis du har brug for mere hjælp.</p>",
+        }
+      }
+
+      const appConfig = {
+        accountSid:"AC6b99858a6faf7af1b572c83988b50eb1",
+        flexFlowSid:"FO57c22d5dfc7a18dcada507aa70ca0cb3",
+        startEngagementOnInit: false,
+        preEngagementConfig: {
+          description: "Let's get started",
+          fields:
+            [{
+              label: "What is your helpline?",
+              type: "SelectItem",
+              attributes: {
+                name: "helpline",
+                required: true,
+                readOnly: false
+              },
+              options: 
+              [
+                {
+                  value: "Select helpline",
+                  label: "Select helpline",
+                  selected: true
+                },
+                {
+                  value: "Børns Vilkår (DK)",
+                  label: "Børns Vilkår (DK)",
+                  selected: false
+                },
+                {
+                  value: "Childhelp (US)",
+                  label: "Childhelp (US)",
+                  selected: false
+                },
+                {
+                  value: "CHILDLINE India (IN)",
+                  label: "CHILDLINE India (IN)",
+                  selected: false
+                },
+                {
+                  value: "Childline South Africa (SA)",
+                  label: "Childline South Africa (SA)",
+                  selected: false
+                },
+                {
+                  value: "ChildLine Zambia (ZM)",
+                  label: "ChildLine Zambia (ZM)",
+                  selected: false
+                },
+                {
+                  value: "Child Helpline Cambodia (KH)",
+                  label: "Child Helpline Cambodia (KH)",
+                  selected: false
+                },
+                {
+                  value: "Jordan River 110 (JO)",
+                  label: "Jordan River 110 (JO)",
+                  selected: false
+                },
+                {
+                  value: "SMILE OF THE CHILD (GR)",
+                  label: "SMILE OF THE CHILD (GR)",
+                  selected: false
+                },
+                {
+                  value: "Telefono Azzurro (IT)",
+                  label: "Telefono Azzurro (IT)",
+                  selected: false
+                },
+                {
+                  value: "BRIS (SE)",
+                  label: "BRIS (SE)",
+                  selected: false
+                },
+                {
+                  value: "2NDFLOOR (US)",
+                  label: "2NDFLOOR (US)",
+                  selected: false
+                },
+                {
+                  value: "Palo Alto Testing (Text)",
+                  label: "Palo Alto Testing (Text)",
+                  selected: false
+                }
+              ]
+            }],
+          submitLabel: "Let's chat!"
+        }
+      };
+
+
+      const defaultLanguage = 'en-US';
+      const initialLanguage = defaultLanguage;
+
+      const mapHelplineLanguage = helpline => {
+        switch (helpline) {
+          case 'Palo Alto Testing (Text)':
+            return 'en-US';
+          default:
+            return defaultLanguage;
+        }
+      }
+
+      Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
+        const { manager } = webchat;
+
+        const twilioStrings = { ...manager.strings }; // save the originals
+        const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
+        const translationErrorMsg = 'Could not translate, using default';
+
+        const changeLanguageWebChat = language => {
+          try {
+            if (language !== defaultLanguage && translations[language]) {
+              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage], ...translations[language] });
+            } else {
+              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
+            }
+            Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body =
+              (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
+            console.log('Translation OK');
+          } catch (err) {
+            window.alert(translationErrorMsg);
+            console.error(translationErrorMsg, err);
+            changeLanguageWebChat(defaultLanguage)
+          }
+        }
+
+        changeLanguageWebChat(initialLanguage);
+
+        //Posting question from preengagement form as users first chat message
+        Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
+          const { question, helpline } = payload.formData;
+
+          // here we might collect caller language (from a another preEngagement select)
+          const helplineLanguage = mapHelplineLanguage(helpline);
+          changeLanguageWebChat(helplineLanguage);
+
+          if (!question)
+            return;
+
+          const { channelSid } = manager.store.getState().flex.session;
+          manager
+            .chatClient.getChannelBySid(channelSid)
+            .then(channel => channel.sendMessage(question));
         });
+
+        // Render WebChat
+        webchat.init();
+      });
     </script>
 </body>
 </html>


### PR DESCRIPTION
Adds a way of localizing the various strings in webchat.
A language can be mapped to a helpline via `mapHelplineLanguage` function. If the translation for a given language does exist, the webchat is translated, if not, the default language (en-US) will be used instead.
The initial lanaguage can be configured by changing `initialLanguage` constant (changes the first render language, for example, for the EntryPointTagline).