### PR TITLE
Hides input until counselor joins chat

### DIFF
--- a/chat-staging.html
+++ b/chat-staging.html
@@ -7,11 +7,10 @@
     <script>
       const translations = {
         'en-US': {
-          BotGreeting: "How can I help?",
-          WelcomeMessage: "Welcome to Toronto Line!",
+          BotGreeting: "Welcome to the helpline.  A counselor will be with you shortly.",
+          WelcomeMessage: "Welcome to Aselo!",
           MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
           MessageInputDisabledReasonHold: "Please hold for a counselor.",
-          ContactingCounselor: "Contacting a counselor.."
         },
         'es': {
           EntryPointTagline: "Chatea con nosotros",
@@ -36,7 +35,7 @@
           PreEngagementDescription: "Comencemos",
 
           BotGreeting: "¿Cómo puedo ayudar?",
-          WelcomeMessage: "¡Bienvenido a Toronto Line!",
+          WelcomeMessage: "¡Bienvenido a Aselo!",
           MessageCanvasTrayContent: "<p>El consejero abandonó el chat. Gracias por contactarnos. Por favor contáctenos nuevamente si necesita más ayuda.</p>",
         },
         'dk': {
@@ -141,8 +140,6 @@
                 // Re-enable input
                 Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
               });
-
-              channel.sendMessage(translations[helplineLanguage].ContactingCounselor);
             });
         });
 

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -128,8 +128,10 @@
           // change disabled message to actual language
           Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[helplineLanguage].MessageInputDisabledReasonHold;
 
-          // if (!question)
-          //   return;
+          // remove message input and send button if disabledReason is not undefined
+          Twilio.FlexWebChat.MessageInput.Content.remove('textarea', {
+            if: props => !!props.disabledReason
+          });
 
           const { channelSid } = manager.store.getState().flex.session;
           manager
@@ -140,6 +142,8 @@
                 // Re-enable input
                 Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
               });
+
+              channel.sendMessage('');
             });
         });
 

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -142,7 +142,7 @@
         setListenerToUnlockInput(channel);
 
         // Generate task by sending empty message (hidden from the UI above)
-        channel.sendMessage(translations[defaultLanguage].AutoFirstMessage);
+        channel.sendMessage(translations[initialLanguage].AutoFirstMessage);
       })
 
       Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
@@ -166,7 +166,7 @@
         // Posting question from preengagement form as users first chat message
         Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
           const { question, helpline } = payload.formData;
-          
+
           // Here we might collect caller language (from a another preEngagement select)
           const helplineLanguage = mapHelplineLanguage(helpline);
           changeLanguageWebChat(helplineLanguage);

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -89,46 +89,75 @@
         }
       }
 
-      Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
-        const { manager } = webchat;
-
+      const getChangeLanguageWebChat = manager => language => {
         const twilioStrings = { ...manager.strings }; // save the originals
         const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
         const translationErrorMsg = 'Could not translate, using default';
-
-        const changeLanguageWebChat = language => {
-          try {
-            if (language !== defaultLanguage && translations[language]) {
-              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage], ...translations[language] });
-            } else {
-              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
-            }
-            Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body =
-              (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
-            console.log('Translation OK');
-          } catch (err) {
-            window.alert(translationErrorMsg);
-            console.error(translationErrorMsg, err);
-            changeLanguageWebChat(defaultLanguage)
+        
+        try {
+          if (language !== defaultLanguage && translations[language]) {
+            setNewStrings({ ...twilioStrings, ...translations[defaultLanguage], ...translations[language] });
+          } else {
+            setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
           }
+          Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body =
+            (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
+          console.log('Translation OK');
+        } catch (err) {
+          window.alert(translationErrorMsg);
+          console.error(translationErrorMsg, err);
+          changeLanguageWebChat(defaultLanguage)
         }
+      }
+
+      const doWithChannel = callback => manager => {
+        const { channelSid } = manager.store.getState().flex.session;
+          manager
+            .chatClient.getChannelBySid(channelSid)
+            .then(channel => {
+              callback(channel);
+            });
+      }
+
+      const setListenerToUnlockInput = channel => {
+        if (!channel) return;
+
+        if (channel.members.size > 1) {
+          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
+          return;
+        }
+       
+        // Adds an event listener that will run only once
+        channel.once("memberJoined", () => {
+          // Re-enable input
+          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
+        });
+      }
+
+      const setChannelOnCreateWebChat = doWithChannel(channel => {
+        setListenerToUnlockInput(channel);
+      });
+
+      const setChannelAfterStartEngagement = doWithChannel(channel => {
+        setListenerToUnlockInput(channel);
+
+        // Generate task by sending empty message (hidden from the UI above)
+        channel.sendMessage(translations[defaultLanguage].AutoFirstMessage);
+      })
+
+      Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
+        const { manager } = webchat;
+        const changeLanguageWebChat = getChangeLanguageWebChat(manager);
 
         changeLanguageWebChat(initialLanguage);
 
-        const channel = manager.chatClient && manager.chatClient.channels.channels.values().next().value;
         // If caller is waiting for a counselor to connect, disable input (default language)
-        if (channel && channel.members.size === 1) {
-          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[initialLanguage].MessageInputDisabledReasonHold;
-          // Adds an event listener that will run only once
-          channel.once("memberJoined", () => {
-            // Re-enable input
-            Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
-          });
-        }
-
+        Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[initialLanguage].MessageInputDisabledReasonHold;
+        if (manager.chatClient) setChannelOnCreateWebChat(manager);
+        
         // Hide message input and send button if disabledReason is not undefined
         Twilio.FlexWebChat.MessageInput.Content.remove('textarea', {
-          if: props => !!props.disabledReason
+          if: props => !!props.disabledReason,
         });
 
         // Hide first message ("AutoFirstMessage", sent to create a new task)
@@ -142,16 +171,11 @@
           const helplineLanguage = mapHelplineLanguage(helpline);
           changeLanguageWebChat(helplineLanguage);
 
-          // Change disabled message to actual language
-          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[helplineLanguage].MessageInputDisabledReasonHold;
+          // Change disabled message to actual language if it exists, default if not
+          const translatedReasonOrDefault = translations[helplineLanguage].MessageInputDisabledReasonHold || translations[initialLanguage].MessageInputDisabledReasonHold;
+          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translatedReasonOrDefault;
 
-          const { channelSid } = manager.store.getState().flex.session;
-          manager
-            .chatClient.getChannelBySid(channelSid)
-            .then(channel => {
-              // Generate task by sending empty message (hidden from the UI above)
-              channel.sendMessage(translations[helplineLanguage].AutoFirstMessage);
-            });
+          setChannelAfterStartEngagement(manager);
         });
 
         // Render WebChat

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -11,6 +11,7 @@
           WelcomeMessage: "Welcome to Aselo!",
           MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
           MessageInputDisabledReasonHold: "Please hold for a counselor.",
+          AutoFirstMessage: "Incoming webchat contact",
         },
         'es': {
           EntryPointTagline: "Chatea con nosotros",
@@ -114,36 +115,42 @@
 
         changeLanguageWebChat(initialLanguage);
 
-        // Disable input (default language)
-        Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[initialLanguage].MessageInputDisabledReasonHold;
+        const channel = manager.chatClient && manager.chatClient.channels.channels.values().next().value;
+        // If caller is waiting for a counselor to connect, disable input (default language)
+        if (channel && channel.members.size === 1) {
+          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[initialLanguage].MessageInputDisabledReasonHold;
+          // Adds an event listener that will run only once
+          channel.once("memberJoined", () => {
+            // Re-enable input
+            Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
+          });
+        }
+
+        // Hide message input and send button if disabledReason is not undefined
+        Twilio.FlexWebChat.MessageInput.Content.remove('textarea', {
+          if: props => !!props.disabledReason
+        });
+
+        // Hide first message ("AutoFirstMessage", sent to create a new task)
+        Twilio.FlexWebChat.MessageList.Content.remove('0');
 
         // Posting question from preengagement form as users first chat message
         Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
           const { question, helpline } = payload.formData;
           
-          // here we might collect caller language (from a another preEngagement select)
+          // Here we might collect caller language (from a another preEngagement select)
           const helplineLanguage = mapHelplineLanguage(helpline);
           changeLanguageWebChat(helplineLanguage);
 
-          // change disabled message to actual language
+          // Change disabled message to actual language
           Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[helplineLanguage].MessageInputDisabledReasonHold;
-
-          // remove message input and send button if disabledReason is not undefined
-          Twilio.FlexWebChat.MessageInput.Content.remove('textarea', {
-            if: props => !!props.disabledReason
-          });
 
           const { channelSid } = manager.store.getState().flex.session;
           manager
             .chatClient.getChannelBySid(channelSid)
             .then(channel => {
-              // adds an event listener that will run only once
-              channel.once("memberJoined", (payload) => {
-                // Re-enable input
-                Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
-              });
-
-              channel.sendMessage('');
+              // Generate task by sending empty message (hidden from the UI above)
+              channel.sendMessage(translations[helplineLanguage].AutoFirstMessage);
             });
         });
 

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -10,6 +10,8 @@
           BotGreeting: "How can I help?",
           WelcomeMessage: "Welcome to Toronto Line!",
           MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
+          MessageInputDisabledReasonHold: "Please hold for a counselor.",
+          ContactingCounselor: "Contacting a counselor.."
         },
         'es': {
           EntryPointTagline: "Chatea con nosotros",
@@ -113,21 +115,35 @@
 
         changeLanguageWebChat(initialLanguage);
 
-        //Posting question from preengagement form as users first chat message
+        // Disable input (default language)
+        Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[initialLanguage].MessageInputDisabledReasonHold;
+
+        // Posting question from preengagement form as users first chat message
         Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
           const { question, helpline } = payload.formData;
-
+          
           // here we might collect caller language (from a another preEngagement select)
           const helplineLanguage = mapHelplineLanguage(helpline);
           changeLanguageWebChat(helplineLanguage);
 
-          if (!question)
-            return;
+          // change disabled message to actual language
+          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[helplineLanguage].MessageInputDisabledReasonHold;
+
+          // if (!question)
+          //   return;
 
           const { channelSid } = manager.store.getState().flex.session;
           manager
             .chatClient.getChannelBySid(channelSid)
-            .then(channel => channel.sendMessage(question));
+            .then(channel => {
+              // adds an event listener that will run only once
+              channel.once("memberJoined", (payload) => {
+                // Re-enable input
+                Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
+              });
+
+              channel.sendMessage(translations[helplineLanguage].ContactingCounselor);
+            });
         });
 
         // Render WebChat


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-199

Hides the input field and send button until a counselor accepts the task.

Waiting for a counselor to join:
![Screenshot from 2020-09-07 15-39-01](https://user-images.githubusercontent.com/15805319/92411960-62611b00-f120-11ea-9349-054c2a9c4e76.png)

Once a counselor joined:
![Screenshot from 2020-09-07 15-39-15](https://user-images.githubusercontent.com/15805319/92411966-69882900-f120-11ea-870a-92b7b56358ed.png)

The task is started by sending a message from the user but hiding it from it's UI. The counselor will still be able to see it:
![Screenshot from 2020-09-07 15-39-22](https://user-images.githubusercontent.com/15805319/92411993-86246100-f120-11ea-8851-7992c4155ac5.png)

