### PR TITLE
Input locked between bot and counselor join to the channel

### DIFF
--- a/chat-staging.html
+++ b/chat-staging.html
@@ -128,17 +128,20 @@
       const setListenerToUnlockInput = (channel, manager) => {
         if (!channel) return;
 
-        if (channel.members.size > 1) {
+        const cb = () => {
+          // Re-enable input
           unlockInput(manager)
-          // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
+        }
+
+        // User is not alone in the channel (possible cause to enter this case is page reload)
+        if (channel.members.size > 1) {
+          cb();
           return;
         }
        
         // Adds an event listener that will run only once
         channel.once("memberJoined", () => {
-          // Re-enable input
-          unlockInput(manager)
-          // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
+          cb();
         });
       }
 
@@ -158,12 +161,18 @@
         changeLanguageWebChat(initialLanguage);
 
         // If caller is waiting for a counselor to connect, disable input (default language)
-        // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[initialLanguage].MessageInputDisabledReasonHold;
         if (manager.chatClient) setChannelOnCreateWebChat(manager);
         
+        // Set caller name to be 'You'
+        Twilio.FlexWebChat.MessagingCanvas.defaultProps.memberDisplayOptions = {
+          yourDefaultName: 'You',
+          yourFriendlyNameOverride: false,
+          theirFriendlyNameOverride: true,
+        };
+
         // Hide message input and send button if disabledReason is not undefined
         Twilio.FlexWebChat.MessageInput.Content.remove('textarea', {
-          if: props => manager.chatClient.user.attributes.lockInput,
+          if: props => {console.log(manager); return manager.chatClient.user.attributes.lockInput},
         });
 
         // Hide first message ("AutoFirstMessage", sent to create a new task)
@@ -176,11 +185,6 @@
           // Here we might collect caller language (from a another preEngagement select)
           const helplineLanguage = mapHelplineLanguage(helpline);
           changeLanguageWebChat(helplineLanguage);
-
-          // Change disabled message to actual language if it exists, default if not
-          const translatedReasonOrDefault = translations[helplineLanguage].MessageInputDisabledReasonHold || translations[initialLanguage].MessageInputDisabledReasonHold;
-    // // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translatedReasonOrDefault;
-          // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
 
           setChannelAfterStartEngagement(manager);
         });

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -115,31 +115,37 @@
           manager
             .chatClient.getChannelBySid(channelSid)
             .then(channel => {
-              callback(channel);
+              callback(channel, manager);
             });
       }
 
-      const setListenerToUnlockInput = channel => {
+      const unlockInput = (manager) => {
+        const { user } = manager.chatClient;
+        const { lockInput, ...attributes } = user.attributes;
+        user.updateAttributes(attributes);
+      }
+
+      const setListenerToUnlockInput = (channel, manager) => {
         if (!channel) return;
 
         if (channel.members.size > 1) {
-          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
+          unlockInput(manager)
+          // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
           return;
         }
        
         // Adds an event listener that will run only once
         channel.once("memberJoined", () => {
           // Re-enable input
-          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
+          unlockInput(manager)
+          // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
         });
       }
 
-      const setChannelOnCreateWebChat = doWithChannel(channel => {
-        setListenerToUnlockInput(channel);
-      });
+      const setChannelOnCreateWebChat = doWithChannel(setListenerToUnlockInput);
 
-      const setChannelAfterStartEngagement = doWithChannel(channel => {
-        setListenerToUnlockInput(channel);
+      const setChannelAfterStartEngagement = doWithChannel((channel, manager) => {
+        setListenerToUnlockInput(channel, manager);
 
         // Generate task by sending empty message (hidden from the UI above)
         channel.sendMessage(translations[initialLanguage].AutoFirstMessage);
@@ -152,12 +158,12 @@
         changeLanguageWebChat(initialLanguage);
 
         // If caller is waiting for a counselor to connect, disable input (default language)
-        Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[initialLanguage].MessageInputDisabledReasonHold;
+        // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translations[initialLanguage].MessageInputDisabledReasonHold;
         if (manager.chatClient) setChannelOnCreateWebChat(manager);
         
         // Hide message input and send button if disabledReason is not undefined
         Twilio.FlexWebChat.MessageInput.Content.remove('textarea', {
-          if: props => !!props.disabledReason,
+          if: props => manager.chatClient.user.attributes.lockInput,
         });
 
         // Hide first message ("AutoFirstMessage", sent to create a new task)
@@ -173,7 +179,8 @@
 
           // Change disabled message to actual language if it exists, default if not
           const translatedReasonOrDefault = translations[helplineLanguage].MessageInputDisabledReasonHold || translations[initialLanguage].MessageInputDisabledReasonHold;
-          Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translatedReasonOrDefault;
+    // // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = translatedReasonOrDefault;
+          // Twilio.FlexWebChat.MessageInput.defaultProps.disabledReason = undefined;
 
           setChannelAfterStartEngagement(manager);
         });

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -7,7 +7,6 @@
     <script>
       const translations = {
         'en-US': {
-          BotGreeting: "Welcome to the helpline.  A counselor will be with you shortly.",
           WelcomeMessage: "Welcome to Aselo!",
           MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
           MessageInputDisabledReasonHold: "Please hold for a counselor.",
@@ -18,8 +17,6 @@
           MessageCanvasTrayButton: "EMPEZAR NUEVO CHAT",
           InvalidPreEngagementMessage: "Los formularios previos al compromiso no se han establecido y son necesarios para iniciar el chat web. Por favor configúrelos ahora en la configuración.",
           InvalidPreEngagementButton: "Aprende más",
-          PredefinedChatMessageAuthorName: "Bot",
-          PredefinedChatMessageBody: "¡Hola! ¿Cómo podemos ayudarte hoy?",
           InputPlaceHolder: "Escribe un mensaje",
           TypingIndicator: "{0} está escribiendo ... ",
           Read: "Visto",
@@ -35,7 +32,6 @@
 
           PreEngagementDescription: "Comencemos",
 
-          BotGreeting: "¿Cómo puedo ayudar?",
           WelcomeMessage: "¡Bienvenido a Aselo!",
           MessageCanvasTrayContent: "<p>El consejero abandonó el chat. Gracias por contactarnos. Por favor contáctenos nuevamente si necesita más ayuda.</p>",
         },
@@ -100,8 +96,7 @@
           } else {
             setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
           }
-          Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body =
-            (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
+
           console.log('Translation OK');
         } catch (err) {
           window.alert(translationErrorMsg);
@@ -162,7 +157,10 @@
 
         // If caller is waiting for a counselor to connect, disable input (default language)
         if (manager.chatClient) setChannelOnCreateWebChat(manager);
-        
+
+        // Disable greeting message as chatbot already includes one
+        Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage = false;
+
         // Set caller name to be 'You'
         Twilio.FlexWebChat.MessagingCanvas.defaultProps.memberDisplayOptions = {
           yourDefaultName: 'You',
@@ -172,7 +170,7 @@
 
         // Hide message input and send button if disabledReason is not undefined
         Twilio.FlexWebChat.MessageInput.Content.remove('textarea', {
-          if: props => {console.log(manager); return manager.chatClient.user.attributes.lockInput},
+          if: props => manager.chatClient.user.attributes.lockInput,
         });
 
         // Hide first message ("AutoFirstMessage", sent to create a new task)


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-249
This PR is related to https://github.com/tech-matters/serverless/pull/22

Input is locked after chatbot survey is completed, and until a counselor joins the chat.

![Screenshot from 2020-09-25 20-09-23](https://user-images.githubusercontent.com/15805319/94323854-c0d62800-ff6d-11ea-8a63-13ce90993065.png)
![Screenshot from 2020-09-25 20-10-16](https://user-images.githubusercontent.com/15805319/94323860-c3d11880-ff6d-11ea-9b01-cbb93ec04b4a.png)


Note:
- There's an error being raised in the console. It happens when user is updated, so maybe it's something related to Twilio's code. Further investigation required.
![Screenshot from 2020-09-25 20-11-46](https://user-images.githubusercontent.com/15805319/94323950-01ce3c80-ff6e-11ea-93ac-94a23cdbd9c1.png)

