### PR TITLE
Upgrade webchat to 2.6 (was: Enable attachments in webchat)

### DIFF
--- a/chat-staging.html
+++ b/chat-staging.html
@@ -3,7 +3,7 @@
     <title>My chat</title>
 </head>
 <body>
-    <script src="https://media.twiliocdn.com/sdk/js/flex-webchat/releases/2.1.2/twilio-flex-webchat.min.js"></script>
+    <script src="https://assets.flex.twilio.com/releases/flex-webchat-ui/2.6.0/twilio-flex-webchat.min.js"></script>
     <script>
       const translations = {
         'en-US': {
@@ -73,6 +73,9 @@
               ]
             }],
           submitLabel: "Let's chat!"
+        },
+        fileAttachment: {
+          enabled: true
         }
       };
 

--- a/chat-staging.html
+++ b/chat-staging.html
@@ -73,9 +73,6 @@
               ]
             }],
           submitLabel: "Let's chat!"
-        },
-        fileAttachment: {
-          enabled: true
         }
       };
 


### PR DESCRIPTION
Update: we're actually going to hold off on attachments for now.  But it's still a good idea to upgrade.

---
This PR updates our webchat package and adds the ability to send and receive attachments ([see Twilio docs](https://www.twilio.com/docs/flex/developer/webchat/enable-attachments)).  We'll experiment with that on staging for now.  @GPaoloni please take a look.

![image](https://user-images.githubusercontent.com/10714292/94749254-4116d780-0338-11eb-8647-1006272d5c26.png)
