### PR TITLE
Replicated changes for production chat

### DIFF
--- a/chat.html
+++ b/chat.html
@@ -13,7 +13,7 @@
           MessageCanvasTrayContent: "<p>Ο σύμβουλος εγκατέλειψε τη συνομιλία. Σας ευχαριστούμε που επικοινωνήσατε. Παρακαλώ επικοινωνήστε μαζί μας ξανά εάν χρειάζεστε περισσότερη βοήθεια.</p>"
         },
         'en-US': {
-          WelcomeMessage: "Welcome to Toronto Line!",
+          WelcomeMessage: "Welcome to Aselo!",
           MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
           MessageInputDisabledReasonHold: "Please hold for a counselor.",
           AutoFirstMessage: "Incoming webchat contact",
@@ -41,7 +41,7 @@
           PreEngagementDescription: "Comencemos",
 
           BotGreeting: "¿Cómo puedo ayudar?",
-          WelcomeMessage: "¡Bienvenido a Toronto Line!",
+          WelcomeMessage: "¡Bienvenido a Aselo!",
           MessageCanvasTrayContent: "<p>El consejero abandonó el chat. Gracias por contactarnos. Por favor contáctenos nuevamente si necesita más ayuda.</p>",
         },
         'da': {

--- a/chat.html
+++ b/chat.html
@@ -13,9 +13,10 @@
           MessageCanvasTrayContent: "<p>Ο σύμβουλος εγκατέλειψε τη συνομιλία. Σας ευχαριστούμε που επικοινωνήσατε. Παρακαλώ επικοινωνήστε μαζί μας ξανά εάν χρειάζεστε περισσότερη βοήθεια.</p>"
         },
         'en-US': {
-          BotGreeting: "How can I help?",
           WelcomeMessage: "Welcome to Toronto Line!",
           MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
+          MessageInputDisabledReasonHold: "Please hold for a counselor.",
+          AutoFirstMessage: "Incoming webchat contact",
         },
         'es': {
           EntryPointTagline: "Chatea con nosotros",
@@ -171,47 +172,106 @@
         }
       }
 
-      Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
-        const { manager } = webchat;
-
+      const getChangeLanguageWebChat = manager => language => {
         const twilioStrings = { ...manager.strings }; // save the originals
         const setNewStrings = newStrings => (manager.strings = { ...manager.strings, ...newStrings });
         const translationErrorMsg = 'Could not translate, using default';
-
-        const changeLanguageWebChat = language => {
-          try {
-            if (language !== defaultLanguage && translations[language]) {
-              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage], ...translations[language] });
-            } else {
-              setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
-            }
-            Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage.body =
-              (translations[language] && translations[language].BotGreeting) || translations[defaultLanguage].BotGreeting;
-            console.log('Translation OK');
-          } catch (err) {
-            window.alert(translationErrorMsg);
-            console.error(translationErrorMsg, err);
-            changeLanguageWebChat(defaultLanguage)
+        
+        try {
+          if (language !== defaultLanguage && translations[language]) {
+            setNewStrings({ ...twilioStrings, ...translations[defaultLanguage], ...translations[language] });
+          } else {
+            setNewStrings({ ...twilioStrings, ...translations[defaultLanguage] });
           }
+
+          console.log('Translation OK');
+        } catch (err) {
+          window.alert(translationErrorMsg);
+          console.error(translationErrorMsg, err);
+          changeLanguageWebChat(defaultLanguage)
         }
+      }
+
+      const doWithChannel = callback => manager => {
+        const { channelSid } = manager.store.getState().flex.session;
+          manager
+            .chatClient.getChannelBySid(channelSid)
+            .then(channel => {
+              callback(channel, manager);
+            });
+      }
+
+      const unlockInput = (manager) => {
+        const { user } = manager.chatClient;
+        const { lockInput, ...attributes } = user.attributes;
+        user.updateAttributes(attributes);
+      }
+
+      const setListenerToUnlockInput = (channel, manager) => {
+        if (!channel) return;
+
+        const cb = () => {
+          // Re-enable input
+          unlockInput(manager)
+        }
+
+        // User is not alone in the channel (possible cause to enter this case is page reload)
+        if (channel.members.size > 1) {
+          cb();
+          return;
+        }
+       
+        // Adds an event listener that will run only once
+        channel.once("memberJoined", () => {
+          cb();
+        });
+      }
+
+      const setChannelOnCreateWebChat = doWithChannel(setListenerToUnlockInput);
+
+      const setChannelAfterStartEngagement = doWithChannel((channel, manager) => {
+        setListenerToUnlockInput(channel, manager);
+
+        // Generate task by sending empty message (hidden from the UI above)
+        channel.sendMessage(translations[initialLanguage].AutoFirstMessage);
+      })
+
+      Twilio.FlexWebChat.createWebChat(appConfig).then(webchat => {
+        const { manager } = webchat;
+        const changeLanguageWebChat = getChangeLanguageWebChat(manager);
 
         changeLanguageWebChat(initialLanguage);
 
-        //Posting question from preengagement form as users first chat message
+        // If caller is waiting for a counselor to connect, disable input (default language)
+        if (manager.chatClient) setChannelOnCreateWebChat(manager);
+
+        // Disable greeting message as chatbot already includes one
+        Twilio.FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage = false;
+
+        // Set caller name to be 'You'
+        Twilio.FlexWebChat.MessagingCanvas.defaultProps.memberDisplayOptions = {
+          yourDefaultName: 'You',
+          yourFriendlyNameOverride: false,
+          theirFriendlyNameOverride: true,
+        };
+
+        // Hide message input and send button if disabledReason is not undefined
+        Twilio.FlexWebChat.MessageInput.Content.remove('textarea', {
+          if: props => manager.chatClient.user.attributes.lockInput,
+        });
+
+        // Hide first message ("AutoFirstMessage", sent to create a new task)
+        Twilio.FlexWebChat.MessageList.Content.remove('0');
+
+        // Posting question from preengagement form as users first chat message
         Twilio.FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
           const { question, helpline } = payload.formData;
 
-          // here we might collect caller language (from a another preEngagement select)
+          // Here we might collect caller language (from a another preEngagement select)
           const helplineLanguage = mapHelplineLanguage(helpline);
           changeLanguageWebChat(helplineLanguage);
 
-          if (!question)
-            return;
-
-          const { channelSid } = manager.store.getState().flex.session;
-          manager
-            .chatClient.getChannelBySid(channelSid)
-            .then(channel => channel.sendMessage(question));
+          setChannelAfterStartEngagement(manager);
         });
 
         // Render WebChat


### PR DESCRIPTION
This PR updates webchat to the current version in staging.

Changes:
- A new message is sent from webchat to trigger a new task right after chat engagement (message hidden to the caller).
- Input hidden after completing the pre-survey with the chatbot, until a counselor joins the channel.
- Caller displayed name changed to "You".