### PR TITLE
Changes spelling of counselor to counsellor

### DIFF
--- a/chat-staging.html
+++ b/chat-staging.html
@@ -8,8 +8,8 @@
       const translations = {
         'en-US': {
           WelcomeMessage: "Welcome to Aselo!",
-          MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
-          MessageInputDisabledReasonHold: "Please hold for a counselor.",
+          MessageCanvasTrayContent: "<p>The counsellor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
+          MessageInputDisabledReasonHold: "Please hold for a counsellor.",
           AutoFirstMessage: "Incoming webchat contact",
         },
         'es': {


### PR DESCRIPTION
Per https://bugs.benetech.org/browse/CHI-302: "It's currently using the US spelling and more of the helplines will use British English so we may as well change it now for the first few implementations."

This does not change any of our variables, just the strings that the user will see.  I have tried to catch everything but please point out anything I've missed.

A companion PR for flex-plugins is here: https://github.com/tech-matters/flex-plugins/pull/247

And we will also need to change two messages in the Autopilot configuration.