### PR TITLE
Fix minified file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6282,6 +6282,12 @@
         }
       }
     },
+    "webpack-utf8-bom": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/webpack-utf8-bom/-/webpack-utf8-bom-1.3.0.tgz",
+      "integrity": "sha512-2oooQzHUuNGk7viY92qShw9J2n7ZOzWIVP201DVNpnWkL9lqB/FVJfknwzwEu1AkN+q+SMTG3xxb/KO36NLacg==",
+      "dev": true
+    },
     "websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "typescript": "^4.1.3",
     "webpack": "^5.21.2",
     "webpack-cli": "^4.5.0",
-    "webpack-dev-server": "^3.11.2"
+    "webpack-dev-server": "^3.11.2",
+    "webpack-utf8-bom": "^1.3.0"
   },
   "dependencies": {
     "@twilio/flex-webchat-ui": "^2.7.1"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,9 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const BomPlugin = require('webpack-utf8-bom');
 
 module.exports = {
-  mode: 'development',
+  mode: 'production',
   devtool: 'source-map',
   devServer: {
     contentBase: './build',
@@ -30,5 +31,6 @@ module.exports = {
     new HtmlWebpackPlugin({
       template: 'src/index.html',
     }),
+    new BomPlugin(true),
   ],
 };


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-530

This PR fixes the minified file so the browser can load it just fine.
The issue was that some dependencies had non-ASCII chars, but the browser tried to read them as ASCII, so it was throwing invalid chars. The use of `webpack-utf8-bom` plugin fixes this issue.