### PR TITLE
Update Counselor Name in Webchat

### DIFF
--- a/configurations/types.ts
+++ b/configurations/types.ts
@@ -1,4 +1,5 @@
 import { FormAttributes as PreEngagementConfig } from '@twilio/flex-ui-core';
+import type { MemberDisplayOptions } from '@twilio/flex-ui-core/src/components/channel/MessagingCanvas';
 
 export type { PreEngagementConfig };
 
@@ -17,4 +18,5 @@ export type Configuration = {
   translations: Translations;
   preEngagementConfig: PreEngagementConfig;
   mapHelplineLanguage: MapHelplineLanguage;
+  memberDisplayOptions?: MemberDisplayOptions;
 };

--- a/configurations/za-prod.ts
+++ b/configurations/za-prod.ts
@@ -11,4 +11,5 @@ export const config: Configuration = {
   translations: zaStaging.translations,
   preEngagementConfig: zaStaging.preEngagementConfig,
   mapHelplineLanguage: zaStaging.mapHelplineLanguage,
+  memberDisplayOptions: zaStaging.memberDisplayOptions,
 };

--- a/configurations/za-staging.ts
+++ b/configurations/za-staging.ts
@@ -46,6 +46,13 @@ const mapHelplineLanguage: MapHelplineLanguage = helpline => {
   }
 }
 
+const memberDisplayOptions = {
+  yourDefaultName: 'You',
+  yourFriendlyNameOverride: false,
+  theirFriendlyNameOverride: false,
+  theirDefaultName: 'Counsellor',
+}
+
 export const config: Configuration = {
   accountSid,
   flexFlowSid,
@@ -53,4 +60,5 @@ export const config: Configuration = {
   translations,
   preEngagementConfig,
   mapHelplineLanguage,
+  memberDisplayOptions,
 };

--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -96,7 +96,10 @@ export const initWebchat = () => FlexWebChat.createWebChat(appConfig).then(webch
   FlexWebChat.MessagingCanvas.defaultProps.predefinedMessage = undefined;
 
   // Set caller name to be 'You'  
-  FlexWebChat.MessagingCanvas.defaultProps.memberDisplayOptions = {
+  FlexWebChat.MessagingCanvas.defaultProps.memberDisplayOptions =
+  currentConfig.memberDisplayOptions
+    ? currentConfig.memberDisplayOptions
+    : {
     yourDefaultName: 'You',
     yourFriendlyNameOverride: false,
     theirFriendlyNameOverride: true,


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-510
Primary reviewer: @murilovmachado 

This PR:
- Adds `memberDisplayOptions` optional property to `Configuration` type, and makes use of it in webchat if it exists (fallback to current behavior if not provided).
- Adds `memberDisplayOptions` overrides to ZA environments.

To test this in development, just add the following to the dev configuration file (`configurations/dev.ts`):
```
...
memberDisplayOptions: {
  yourDefaultName: 'You',
  yourFriendlyNameOverride: false,
  theirFriendlyNameOverride: false,
  theirDefaultName: 'Counsellor',
}
...
```