### PR TITLE
Webchat Localization for Zambia native languages

### DIFF
--- a/configurations/dev.ts
+++ b/configurations/dev.ts
@@ -37,7 +37,7 @@ const translations: Translations = {
   },
   'dk': {
     MessageCanvasTrayContent:"",
-  }
+  },
 };
 
 const preEngagementConfig: PreEngagementConfig = {

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -169,15 +169,6 @@ const preEngagementConfig: PreEngagementConfig = {
         }
       ],
     },
-    {
-      // shows nothing but forces the form to show up
-      type: '',
-      label: '',
-      attributes: {
-        name: 'helpline',
-        value: 'ChildLine Zambia (ZM)',
-      },
-    },
   ],
   submitLabel: 'Start Chat!',
 };

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -182,6 +182,13 @@ const preEngagementConfig: PreEngagementConfig = {
   submitLabel: 'Start Chat!',
 };
 
+const memberDisplayOptions = {
+  yourDefaultName: 'You',
+  yourFriendlyNameOverride: false,
+  theirFriendlyNameOverride: false,
+  theirDefaultName: 'ChildLine Zambia Counsellor',
+}
+
 const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
@@ -196,5 +203,6 @@ export const config: Configuration = {
   translations,
   preEngagementConfig,
   mapHelplineLanguage,
+  memberDisplayOptions,
   captureIp,
 };

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -1,4 +1,9 @@
-import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage } from './types';
+import {
+  PreEngagementConfig,
+  Translations,
+  Configuration,
+  MapHelplineLanguage,
+} from './types';
 
 const accountSid = 'ACc59300c7ca018e8652e4d6d86c2d50e6';
 const flexFlowSid = 'FObb9dfe97f1c59f455ab01811bec74cd5';
@@ -7,109 +12,182 @@ const captureIp = true;
 
 const translations: Translations = {
   'en-US': {
-    MessageInputDisabledReasonHold: "We'll transfer you now. Please hold for a counsellor.",
-    EntryPointTagLine: "Chat with us",
+    MessageInputDisabledReasonHold:
+      "We'll transfer you now. Please hold for a counsellor.",
+    EntryPointTagLine: 'Chat with us',
     PreEngagementDescription: "Let's get started",
-    Today: "Today",
-    InputPlaceHolder: "Type Message",
-    WelcomeMessage: "Welcome to ChildLine Zambia!",
-    Yesterday: "Yesterday",
-    TypingIndicator: "Counselor is typing",
-    MessageCanvasTrayButton: "Start New Chat",
-    MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
-    AutoFirstMessage: "Incoming webchat contact",
-    StartChat: "Start Chat!",
+    Today: 'Today',
+    InputPlaceHolder: 'Type Message',
+    WelcomeMessage: 'Welcome to ChildLine Zambia!',
+    Yesterday: 'Yesterday',
+    TypingIndicator: 'Counselor is typing',
+    MessageCanvasTrayButton: 'Start New Chat',
+    MessageCanvasTrayContent:
+      '<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>',
+    AutoFirstMessage: 'Incoming webchat contact',
+    StartChat: 'Start Chat!',
   },
-  'Bemba': {
-    MessageInputDisabledReasonHold: "Twalamutuma nomba kuli Chimbusa, pembeleni ichimpusa nomba.",
-    EntryPointTagLine: "Landeni naifwe",
-    PreEngagementDescription: "tiyeni twambeko ilyashi",
-    Today: "Lelo",
-    InputPlaceHolder: "Taipeni ilyashi",
-    WelcomeMessage: "Mwaiseni kuli ChildLine Zambia!",
-    Yesterday: "Mailo",
-    TypingIndicator: "Ichimbusa chile taipa ilyashi",
-    MessageCanvasTrayButton: "Yambeni kutaipa ilyashi imbi",
-    MessageCanvasTrayContent: "<p>Ichimbusa chapwisha imilimo yakulanda.Twatotela pakutuma kuno.Mukatutumine nakabili nga mwafwaya ubwafwilisho kuli baifwe.</p>",
-    StartChat: "Yambeni ukulanda mukwai!",
+  Bemba: {
+    MessageInputDisabledReasonHold:
+      'Twalamutuma nomba kuli Chimbusa, pembeleni ichimpusa nomba.',
+    EntryPointTagLine: 'Landeni naifwe',
+    PreEngagementDescription: 'tiyeni twambeko ilyashi',
+    Today: 'Lelo',
+    InputPlaceHolder: 'Taipeni ilyashi',
+    WelcomeMessage: 'Mwaiseni kuli ChildLine Zambia!',
+    Yesterday: 'Mailo',
+    TypingIndicator: 'Ichimbusa chile taipa ilyashi',
+    MessageCanvasTrayButton: 'Yambeni kutaipa ilyashi imbi',
+    MessageCanvasTrayContent:
+      '<p>Ichimbusa chapwisha imilimo yakulanda.Twatotela pakutuma kuno.Mukatutumine nakabili nga mwafwaya ubwafwilisho kuli baifwe.</p>',
+    StartChat: 'Yambeni ukulanda mukwai!',
   },
-  'Tonga': {
-    MessageInputDisabledReasonHold: "Tulamuswaanganya lino asikuyumya-yumya/sikulaya. Amujatilile notucimuswaanganya.",
-    EntryPointTagLine: "Amubandike andiswe",
-    PreEngagementDescription: "Atukanke/atutalike",
-    Today: "Sunu",
+  Tonga: {
+    MessageInputDisabledReasonHold:
+      'Tulamuswaanganya lino asikuyumya-yumya/sikulaya. Amujatilile notucimuswaanganya.',
+    EntryPointTagLine: 'Amubandike andiswe',
+    PreEngagementDescription: 'Atukanke/atutalike',
+    Today: 'Sunu',
     InputPlaceHolder: "Lemba kang'wadi/kagwalo",
-    WelcomeMessage: "Mwatambulwa ku ChildLine Zambia!",
-    Yesterday: "Jilo",
-    TypingIndicator: "Sikuyumyayumya watalika kulemba",
-    MessageCanvasTrayButton: "Talika mubandi mupya",
-    MessageCanvasTrayContent: "<p>Sikulaya/sikuyumyayumyawazwa lino amubandi. Twalumba kukwabana andiswe,Inga mwatuma lubo naa muciyanda lumbi lugwasyo.</p>",
-    StartChat: "Atubandike!",
+    WelcomeMessage: 'Mwatambulwa ku ChildLine Zambia!',
+    Yesterday: 'Jilo',
+    TypingIndicator: 'Sikuyumyayumya watalika kulemba',
+    MessageCanvasTrayButton: 'Talika mubandi mupya',
+    MessageCanvasTrayContent:
+      '<p>Sikulaya/sikuyumyayumyawazwa lino amubandi. Twalumba kukwabana andiswe,Inga mwatuma lubo naa muciyanda lumbi lugwasyo.</p>',
+    StartChat: 'Atubandike!',
   },
-  'Lunda': {
-    MessageInputDisabledReasonHold: "Chuna kuitemesha ahembeleliku chanti kundi ankhong'u.",
-    EntryPointTagLine: "Tuhanjiki mwani",
-    PreEngagementDescription: "Tutachikiku",
-    Today: "Lelu",
-    InputPlaceHolder: "Sonekenu Muzhimbu",
-    WelcomeMessage: "Shikenu mwani kuchota cha ChildLine Zambia!",
-    Yesterday: "Haloshi",
+  Lunda: {
+    MessageInputDisabledReasonHold:
+      "Chuna kuitemesha ahembeleliku chanti kundi ankhong'u.",
+    EntryPointTagLine: 'Tuhanjiki mwani',
+    PreEngagementDescription: 'Tutachikiku',
+    Today: 'Lelu',
+    InputPlaceHolder: 'Sonekenu Muzhimbu',
+    WelcomeMessage: 'Shikenu mwani kuchota cha ChildLine Zambia!',
+    Yesterday: 'Haloshi',
     TypingIndicator: "Nkhong'u nakusoneka Muzhimbu",
-    MessageCanvasTrayButton: "Tachikenu kuhanjika",
-    MessageCanvasTrayContent: "<p>Ankhong'u adihu wanyi kusakililaku mwani, hakushika kudechu, mwani anachweshi kuchuma mpinji.</p>",
-    StartChat: "Tachikenu kuhanjeka!",
+    MessageCanvasTrayButton: 'Tachikenu kuhanjika',
+    MessageCanvasTrayContent:
+      "<p>Ankhong'u adihu wanyi kusakililaku mwani, hakushika kudechu, mwani anachweshi kuchuma mpinji.</p>",
+    StartChat: 'Tachikenu kuhanjeka!',
   },
-  'Nyanja': {
-    MessageInputDisabledReasonHold: "Chonde tipeleka lamya lanu ku wa uphungu telo dikilani.",
-    EntryPointTagLine: "Lankhulisanani nafe!",
-    PreEngagementDescription: "Tiyeni tiyembe kulankhulisana",
-    Today: "Lelo",
-    InputPlaceHolder: "Lembani zimene zimene mufuna kulemba",
-    WelcomeMessage: "Mwalandilidwa kuno ku ChildLine Zambia!",
-    Yesterday: "Dzulo!",
-    TypingIndicator: "Wauphungu alikulemba!",
-    MessageCanvasTrayButton: "Yambani nkhani ina!",
-    MessageCanvasTrayContent: "<p>Wauphungu achoka mkukambitsana nanu. Zikomo kwambili pa kukwanisa.</p>",
-    StartChat: "Yambani kulankhula!",
+  Nyanja: {
+    MessageInputDisabledReasonHold:
+      'Chonde tipeleka lamya lanu ku wa uphungu telo dikilani.',
+    EntryPointTagLine: 'Lankhulisanani nafe!',
+    PreEngagementDescription: 'Tiyeni tiyembe kulankhulisana',
+    Today: 'Lelo',
+    InputPlaceHolder: 'Lembani zimene zimene mufuna kulemba',
+    WelcomeMessage: 'Mwalandilidwa kuno ku ChildLine Zambia!',
+    Yesterday: 'Dzulo!',
+    TypingIndicator: 'Wauphungu alikulemba!',
+    MessageCanvasTrayButton: 'Yambani nkhani ina!',
+    MessageCanvasTrayContent:
+      '<p>Wauphungu achoka mkukambitsana nanu. Zikomo kwambili pa kukwanisa.</p>',
+    StartChat: 'Yambani kulankhula!',
   },
-  'Kaonde': {
-    MessageInputDisabledReasonHold: "Tusakwimi tuma pembelelai, pacheche ba nkwasho.",
-    EntryPointTagLine: "Isambai natweba",
-    PreEngagementDescription: "Twayayi tutatule",
-    Today: "Lelo",
-    InputPlaceHolder: "Lembayi mulubwe",
-    WelcomeMessage: "Mwaiyayi mwani ku ChildLine Zambia!",
-    Yesterday: "Kesha",
-    TypingIndicator: "Nkwasho wena kunemba",
-    MessageCanvasTrayButton: "Tatulayi kwisamba kipya kipya",
-    MessageCanvasTrayContent: "<p>Nkwasho wafumapo twasanta pakufika kwiatweba, mwakonsha kutuma lamya.</p>",
-    StartChat: "Twayayi twisambe!",
+  Kaonde: {
+    MessageInputDisabledReasonHold:
+      'Tusakwimi tuma pembelelai, pacheche ba nkwasho.',
+    EntryPointTagLine: 'Isambai natweba',
+    PreEngagementDescription: 'Twayayi tutatule',
+    Today: 'Lelo',
+    InputPlaceHolder: 'Lembayi mulubwe',
+    WelcomeMessage: 'Mwaiyayi mwani ku ChildLine Zambia!',
+    Yesterday: 'Kesha',
+    TypingIndicator: 'Nkwasho wena kunemba',
+    MessageCanvasTrayButton: 'Tatulayi kwisamba kipya kipya',
+    MessageCanvasTrayContent:
+      '<p>Nkwasho wafumapo twasanta pakufika kwiatweba, mwakonsha kutuma lamya.</p>',
+    StartChat: 'Twayayi twisambe!',
+  },
+  Lozi: {
+    MessageInputDisabledReasonHold:
+      "Luka kuisa ku mwelezi, u libelele hanyani.",
+    EntryPointTagLine: 'Alukalise kwa mbola',
+    PreEngagementDescription: "A lukaliseni kwa mbola",
+    Today: 'Lelo',
+    InputPlaceHolder: 'Nola linusa',
+    WelcomeMessage: 'Wamuhezwi ku ba ChildLine Zambia!',
+    Yesterday: 'Mabani',
+    TypingIndicator: 'Mwelezi wa nola',
+    MessageCanvasTrayButton: 'Alukalise kwa mbola',
+    MessageCanvasTrayContent:
+      '<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>',
+    AutoFirstMessage: 'Incoming webchat contact',
+    StartChat: 'Alukalise kwa mbola!',
   },
 };
 
 const preEngagementConfig: PreEngagementConfig = {
   description: "Let's get started",
-  fields:
-    [
-      {
-        // shows nothing but forces the form to show up
-        type: "",
-        label: "",
-        attributes: {
-          name: "helpline",
-          value: "ChildLine Zambia (ZM)",
+  fields: [
+    {
+      label: 'Select your language',
+      type: 'SelectItem',
+      attributes: {
+        name: 'language',
+        required: true,
+        readOnly: false,
+      },
+      options: [
+        {
+          value: 'English',
+          label: '1. English',
+          selected: true,
+        },
+        {
+          value: 'Bemba',
+          label: '2. Bemba',
+          selected: false,
+        },
+        {
+          value: 'Tonga',
+          label: '3. Tonga',
+          selected: false,
+        },
+        {
+          value: 'Lunda',
+          label: '4. Lunda',
+          selected: false,
+        },
+        {
+          value: 'Nyanja',
+          label: '5. Nyanja',
+          selected: false,
+        },
+        {
+          value: 'Kaonde',
+          label: '6. Kaonde',
+          selected: false,
+        },
+        {
+          value: 'Lozi',
+          label: '7. Lozi',
+          selected: false,
         }
-      }
-    ],
-  submitLabel: "Start Chat!"
+      ],
+    },
+    {
+      // shows nothing but forces the form to show up
+      type: '',
+      label: '',
+      attributes: {
+        name: 'helpline',
+        value: 'ChildLine Zambia (ZM)',
+      },
+    },
+  ],
+  submitLabel: 'Start Chat!',
 };
 
-const mapHelplineLanguage: MapHelplineLanguage = helpline => {
+const mapHelplineLanguage: MapHelplineLanguage = (helpline) => {
   switch (helpline) {
     default:
       return defaultLanguage;
   }
-}
+};
 
 export const config: Configuration = {
   accountSid,

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -18,6 +18,7 @@ const translations: Translations = {
     MessageCanvasTrayButton: "Start New Chat",
     MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
     AutoFirstMessage: "Incoming webchat contact",
+    StartChat: "Start Chat!",
   },
   'Bemba': {
     MessageInputDisabledReasonHold: "Twalamutuma nomba kuli Chimbusa, pembeleni ichimpusa nomba.",
@@ -29,7 +30,8 @@ const translations: Translations = {
     Yesterday: "Mailo",
     TypingIndicator: "Ichimbusa chile taipa ilyashi",
     MessageCanvasTrayButton: "Yambeni kutaipa ilyashi imbi",
-    MessageCanvasTrayContent: "Ichimbusa chapwisha imilimo yakulanda.Twatotela pakutuma kuno.Mukatutumine nakabili nga mwafwaya ubwafwilisho kuli baifwe.",
+    MessageCanvasTrayContent: "<p>Ichimbusa chapwisha imilimo yakulanda.Twatotela pakutuma kuno.Mukatutumine nakabili nga mwafwaya ubwafwilisho kuli baifwe.</p>",
+    StartChat: "Yambeni ukulanda mukwai!",
   },
   'Tonga': {
     MessageInputDisabledReasonHold: "Tulamuswaanganya lino asikuyumya-yumya/sikulaya. Amujatilile notucimuswaanganya.",
@@ -41,7 +43,8 @@ const translations: Translations = {
     Yesterday: "Jilo",
     TypingIndicator: "Sikuyumyayumya watalika kulemba",
     MessageCanvasTrayButton: "Talika mubandi mupya",
-    MessageCanvasTrayContent: "Sikulaya/sikuyumyayumyawazwa lino amubandi. Twalumba kukwabana andiswe,Inga mwatuma lubo naa muciyanda lumbi lugwasyo.",
+    MessageCanvasTrayContent: "<p>Sikulaya/sikuyumyayumyawazwa lino amubandi. Twalumba kukwabana andiswe,Inga mwatuma lubo naa muciyanda lumbi lugwasyo.</p>",
+    StartChat: "Atubandike!",
   },
   'Lunda': {
     MessageInputDisabledReasonHold: "Chuna kuitemesha ahembeleliku chanti kundi ankhong'u.",
@@ -53,7 +56,8 @@ const translations: Translations = {
     Yesterday: "Haloshi",
     TypingIndicator: "Nkhong'u nakusoneka Muzhimbu",
     MessageCanvasTrayButton: "Tachikenu kuhanjika",
-    MessageCanvasTrayContent: "Ankhong'u adihu wanyi kusakililaku mwani, hakushika kudechu, mwani anachweshi kuchuma mpinji.",
+    MessageCanvasTrayContent: "<p>Ankhong'u adihu wanyi kusakililaku mwani, hakushika kudechu, mwani anachweshi kuchuma mpinji.</p>",
+    StartChat: "Tachikenu kuhanjeka!",
   },
   'Nyanja': {
     MessageInputDisabledReasonHold: "Chonde tipeleka lamya lanu ku wa uphungu telo dikilani.",
@@ -65,7 +69,8 @@ const translations: Translations = {
     Yesterday: "Dzulo!",
     TypingIndicator: "Wauphungu alikulemba!",
     MessageCanvasTrayButton: "Yambani nkhani ina!",
-    MessageCanvasTrayContent: "Wauphungu achoka mkukambitsana nanu. Zikomo kwambili pa kukwanisa.",
+    MessageCanvasTrayContent: "<p>Wauphungu achoka mkukambitsana nanu. Zikomo kwambili pa kukwanisa.</p>",
+    StartChat: "Yambani kulankhula!",
   },
   'Kaonde': {
     MessageInputDisabledReasonHold: "Tusakwimi tuma pembelelai, pacheche ba nkwasho.",
@@ -77,7 +82,8 @@ const translations: Translations = {
     Yesterday: "Kesha",
     TypingIndicator: "Nkwasho wena kunemba",
     MessageCanvasTrayButton: "Tatulayi kwisamba kipya kipya",
-    MessageCanvasTrayContent: "Nkwasho wafumapo twasanta pakufika kwiatweba, mwakonsha kutuma lamya.",
+    MessageCanvasTrayContent: "<p>Nkwasho wafumapo twasanta pakufika kwiatweba, mwakonsha kutuma lamya.</p>",
+    StartChat: "Twayayi twisambe!",
   },
 };
 

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -2,7 +2,7 @@ import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage }
 
 const accountSid = 'ACc59300c7ca018e8652e4d6d86c2d50e6';
 const flexFlowSid = 'FObb9dfe97f1c59f455ab01811bec74cd5';
-const defaultLanguage = 'Bemba';
+const defaultLanguage = 'en-US';
 const captureIp = true;
 
 const translations: Translations = {

--- a/configurations/zm-staging.ts
+++ b/configurations/zm-staging.ts
@@ -2,15 +2,82 @@ import { PreEngagementConfig, Translations, Configuration, MapHelplineLanguage }
 
 const accountSid = 'ACc59300c7ca018e8652e4d6d86c2d50e6';
 const flexFlowSid = 'FObb9dfe97f1c59f455ab01811bec74cd5';
-const defaultLanguage = 'en-US';
+const defaultLanguage = 'Bemba';
 const captureIp = true;
 
 const translations: Translations = {
   'en-US': {
+    MessageInputDisabledReasonHold: "We'll transfer you now. Please hold for a counsellor.",
+    EntryPointTagLine: "Chat with us",
+    PreEngagementDescription: "Let's get started",
+    Today: "Today",
+    InputPlaceHolder: "Type Message",
     WelcomeMessage: "Welcome to ChildLine Zambia!",
+    Yesterday: "Yesterday",
+    TypingIndicator: "Counselor is typing",
+    MessageCanvasTrayButton: "Start New Chat",
     MessageCanvasTrayContent: "<p>The counselor has left the chat. Thank you for reaching out. Please contact us again if you need more help.</p>",
-    MessageInputDisabledReasonHold: "Please hold for a counselor.",
     AutoFirstMessage: "Incoming webchat contact",
+  },
+  'Bemba': {
+    MessageInputDisabledReasonHold: "Twalamutuma nomba kuli Chimbusa, pembeleni ichimpusa nomba.",
+    EntryPointTagLine: "Landeni naifwe",
+    PreEngagementDescription: "tiyeni twambeko ilyashi",
+    Today: "Lelo",
+    InputPlaceHolder: "Taipeni ilyashi",
+    WelcomeMessage: "Mwaiseni kuli ChildLine Zambia!",
+    Yesterday: "Mailo",
+    TypingIndicator: "Ichimbusa chile taipa ilyashi",
+    MessageCanvasTrayButton: "Yambeni kutaipa ilyashi imbi",
+    MessageCanvasTrayContent: "Ichimbusa chapwisha imilimo yakulanda.Twatotela pakutuma kuno.Mukatutumine nakabili nga mwafwaya ubwafwilisho kuli baifwe.",
+  },
+  'Tonga': {
+    MessageInputDisabledReasonHold: "Tulamuswaanganya lino asikuyumya-yumya/sikulaya. Amujatilile notucimuswaanganya.",
+    EntryPointTagLine: "Amubandike andiswe",
+    PreEngagementDescription: "Atukanke/atutalike",
+    Today: "Sunu",
+    InputPlaceHolder: "Lemba kang'wadi/kagwalo",
+    WelcomeMessage: "Mwatambulwa ku ChildLine Zambia!",
+    Yesterday: "Jilo",
+    TypingIndicator: "Sikuyumyayumya watalika kulemba",
+    MessageCanvasTrayButton: "Talika mubandi mupya",
+    MessageCanvasTrayContent: "Sikulaya/sikuyumyayumyawazwa lino amubandi. Twalumba kukwabana andiswe,Inga mwatuma lubo naa muciyanda lumbi lugwasyo.",
+  },
+  'Lunda': {
+    MessageInputDisabledReasonHold: "Chuna kuitemesha ahembeleliku chanti kundi ankhong'u.",
+    EntryPointTagLine: "Tuhanjiki mwani",
+    PreEngagementDescription: "Tutachikiku",
+    Today: "Lelu",
+    InputPlaceHolder: "Sonekenu Muzhimbu",
+    WelcomeMessage: "Shikenu mwani kuchota cha ChildLine Zambia!",
+    Yesterday: "Haloshi",
+    TypingIndicator: "Nkhong'u nakusoneka Muzhimbu",
+    MessageCanvasTrayButton: "Tachikenu kuhanjika",
+    MessageCanvasTrayContent: "Ankhong'u adihu wanyi kusakililaku mwani, hakushika kudechu, mwani anachweshi kuchuma mpinji.",
+  },
+  'Nyanja': {
+    MessageInputDisabledReasonHold: "Chonde tipeleka lamya lanu ku wa uphungu telo dikilani.",
+    EntryPointTagLine: "Lankhulisanani nafe!",
+    PreEngagementDescription: "Tiyeni tiyembe kulankhulisana",
+    Today: "Lelo",
+    InputPlaceHolder: "Lembani zimene zimene mufuna kulemba",
+    WelcomeMessage: "Mwalandilidwa kuno ku ChildLine Zambia!",
+    Yesterday: "Dzulo!",
+    TypingIndicator: "Wauphungu alikulemba!",
+    MessageCanvasTrayButton: "Yambani nkhani ina!",
+    MessageCanvasTrayContent: "Wauphungu achoka mkukambitsana nanu. Zikomo kwambili pa kukwanisa.",
+  },
+  'Kaonde': {
+    MessageInputDisabledReasonHold: "Tusakwimi tuma pembelelai, pacheche ba nkwasho.",
+    EntryPointTagLine: "Isambai natweba",
+    PreEngagementDescription: "Twayayi tutatule",
+    Today: "Lelo",
+    InputPlaceHolder: "Lembayi mulubwe",
+    WelcomeMessage: "Mwaiyayi mwani ku ChildLine Zambia!",
+    Yesterday: "Kesha",
+    TypingIndicator: "Nkwasho wena kunemba",
+    MessageCanvasTrayButton: "Tatulayi kwisamba kipya kipya",
+    MessageCanvasTrayContent: "Nkwasho wafumapo twasanta pakufika kwiatweba, mwakonsha kutuma lamya.",
   },
 };
 

--- a/src/aselo-webchat.ts
+++ b/src/aselo-webchat.ts
@@ -123,11 +123,10 @@ export const initWebchat = async () => {
 
   // Posting question from preengagement form as users first chat message
   FlexWebChat.Actions.on("afterStartEngagement", (payload) => {
-    const { question, helpline } = payload.formData;
+    const { language } = payload.formData;
 
-    // Here we might collect caller language (from a another preEngagement select)
-    const helplineLanguage = currentConfig.mapHelplineLanguage(helpline);
-    changeLanguageWebChat(helplineLanguage);
+    // Here we collect caller language (from preEngagement select) and change UI language
+    changeLanguageWebChat(language);
 
     setChannelAfterStartEngagement(manager);
   });


### PR DESCRIPTION
Jira: https://bugs.benetech.org/browse/CHI-528

Translations: https://benetech.app.box.com/file/801878647572

Change Description:
- Added Translated messages for each WebChat component using [Twilio's Templated Strings](https://www.twilio.com/docs/flex/developer/webchat/localization-and-templating#list-of-templated-strings-in-webchat).
- Added a dropdown to collect the user's language selection.

How to test this PR:
1. Executre `npm run build:zm-staging`.
2. Open `build/index.html` file in a browser.
3. Open ZM Staging environment in Okta and start a conversation.